### PR TITLE
update: DockerfileのtimzoneをAsia/Tokyoに変更

### DIFF
--- a/demo_docker/Dockerfile
+++ b/demo_docker/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:22.04
 
 ARG VERSION
 
-RUN apt update && apt install -y wget unzip
+# timezoneをAsia/Tokyoに設定
+RUN apt update && apt install -y tzdata wget unzip
+ENV TZ=Asia/Tokyo
 RUN wget https://github.com/acompany-develop/Gramine-EIM-Synth-DEMO/releases/download/${VERSION}/lib-v${VERSION}-linux-x64.zip
 RUN unzip lib-v${VERSION}-linux-x64.zip
 RUN mkdir -p /usr/lib/x86_64-linux-gnu/ && cp -r usr-lib-x86_64-linux-gnu/* /usr/lib/x86_64-linux-gnu/

--- a/demo_docker/docker-compose.yaml
+++ b/demo_docker/docker-compose.yaml
@@ -64,8 +64,8 @@ services:
       - /bin/bash
       - '-c'
       - |
-        # NOTE: firm_demo1_eimと実行が被らないように終了ファイルを確認するまで実行しない
-        while [ ! -f /sync/firm_demo1_eim_done ]; do sleep 1; done && \
+        # NOTE: firm_demo0_eimとfirm_demo1_eimの実行完了を確認するまで実行しない
+        while [ ! -f /sync/firm_demo0_eim_done ] || [ ! -f /sync/firm_demo1_eim_done ]; do sleep 1; done && \
         ./synth ./settings_client.ini /output/model.pkl
     depends_on:
       - firm_demo1_eim


### PR DESCRIPTION
- DockerfileのtimzoneをAsia/Tokyoに変更
- ついでにsynthの実行をeim0, eim1の実行完了を明示的に待つように変更