### PR TITLE
[DCRDEV-322] feat: arm64ベースのPCで利用する方法を記載

### DIFF
--- a/demo_docker/README.md
+++ b/demo_docker/README.md
@@ -63,6 +63,11 @@ $ cd demo_docker
 $ make run
 ```
 
+### 注意事項
+amd64でコンパイルしたバイナリを実行するために、platformを`linux/amd64`に指定しています。この指定下でarm64ベースのmacを使用する場合[Dockerイメージのビルドに失敗するため、Docker DesktopにおいてRossetaを無効化](https://github.com/docker/for-mac/issues/7255)してください。
+
+
+
 ## バイナリでの実行方法
 ### 前準備
 ※ 以下、`${VERSION}`部分は`x.x.x`の形式で有効なバージョンを指定してください。有効なバージョン一覧は[こちら](https://github.com/acompany-develop/Gramine-EIM-Synth-DEMO/tags)を参照。
@@ -90,7 +95,10 @@ $ ./matching <設定ファイルのパス> <入力csvのパス>
 $ ./synth <設定ファイルのパス> <出力modelのパス(任意)>
 ```
 
-## 注意事項
+### 注意事項
+arm64ベースのmacを使用する場合、SIP(System Integrity Protection)が有効なため、後述の`/usr`ディレクトリにファイルを配置することはできません。クラウドでamd64ベースのインスタンスを立てるか、上記のDockerを用いる方法を利用してください。
+
+## 全体注意事項
 ### 実行中の処理を中断した場合
 クライエントがCtrl+Cなどによって処理を途中で終了させた場合、サーバがリクエストを正しく捌けなくなることがある。
 異常な挙動が起きた場合は、[/stop](#stop) API を用いてサーバを停止させる。

--- a/demo_docker/docker-compose.yaml
+++ b/demo_docker/docker-compose.yaml
@@ -14,6 +14,7 @@ networks:
 services:
   firm_demo0_eim:
     <<: *build
+    platform: linux/amd64
     volumes:
       - sync_volume:/sync
       - type: bind
@@ -35,6 +36,7 @@ services:
 
   firm_demo1_eim:
     <<: *build
+    platform: linux/amd64
     volumes:
       - sync_volume:/sync  # ボリュームを共有
       - type: bind
@@ -64,6 +66,7 @@ services:
 
   firm_demo1_synth:
     <<: *build
+    platform: linux/amd64
     volumes:
       - sync_volume:/sync  # ボリュームを共有
       - type: bind
@@ -79,8 +82,8 @@ services:
       - |
         # NOTE: firm_demo0_eimとfirm_demo1_eimの実行完了を確認するまで実行しない
         while [ ! -f /sync/firm_demo0_eim_done ] || [ ! -f /sync/firm_demo1_eim_done ]; do \
-            if [ -f /sync/firm_demo1_eim_failed ]; then exit 1; fi && \
-            sleep 1; \
+          if [ -f /sync/firm_demo1_eim_failed ]; then exit 1; fi && \
+          sleep 1; \
         done && \
         ./synth ./settings_client.ini /output/model.pkl
     depends_on:


### PR DESCRIPTION
## 背景
- m2, m3 mac で x86_64 向けにビルドされたバイナリが動作しない状態だった
- ローカルでのクライアント動作確認ができない状態

## 概要
- arm ベースの mac でバイナリが動作するように Docker イメージの platform を変更
- README に mac を利用する場合の注意事項を記載

## 備考
platformを変更したイメージのビルド時に発生したissue
https://github.com/docker/for-mac/issues/7255